### PR TITLE
Share cross sysroots with Glide

### DIFF
--- a/.github/workflows/prepare_cross_sysroots.yml
+++ b/.github/workflows/prepare_cross_sysroots.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            mmdebstrap debian-archive-keyring zstd pkg-config \
+            mmdebstrap debian-archive-keyring gnupg zstd pkg-config \
             ${{ matrix.compiler_packages }}
 
       - name: Create Bullseye sysroot without QEMU

--- a/scripts/create_cross_sysroot.sh
+++ b/scripts/create_cross_sysroot.sh
@@ -26,6 +26,10 @@ if ! command -v mmdebstrap >/dev/null 2>&1; then
   echo "mmdebstrap is required to create the cross sysroot." >&2
   exit 1
 fi
+if ! command -v gpg >/dev/null 2>&1; then
+  echo "gpg is required to verify the Debian archive used for the cross sysroot." >&2
+  exit 1
+fi
 
 packages=(
   libc6-dev
@@ -42,6 +46,12 @@ packages=(
   libgstreamer1.0-dev
   libgstreamer-plugins-base1.0-dev
   libv4l-dev
+  libdrm-dev
+  libgbm-dev
+  libegl1-mesa-dev
+  libgles2-mesa-dev
+  libfreetype6-dev
+  zlib1g-dev
 )
 package_csv="$(IFS=,; echo "${packages[*]}")"
 
@@ -86,6 +96,9 @@ printf '%s\n' \
 
 test -f "${output_dir}/usr/include/Poco/Poco.h"
 test -f "${output_dir}/usr/include/gstreamer-1.0/gst/gst.h"
+test -f "${output_dir}/usr/include/gbm.h"
+test -f "${output_dir}/usr/include/EGL/egl.h"
+test -f "${output_dir}/usr/include/GLES2/gl2.h"
 find "${output_dir}/usr/lib" -name 'libPocoFoundation.so*' -print -quit | grep -q .
 
 echo "Created ${suite}/${architecture} OpenHD sysroot at ${output_dir}"

--- a/scripts/validate_cross_sysroot.sh
+++ b/scripts/validate_cross_sysroot.sh
@@ -27,12 +27,36 @@ fi
 
 output="$(mktemp)"
 trap 'rm -f "${output}"' EXIT
+read -r -a pkg_config_flags <<<"$(
+  pkg-config --cflags --libs \
+    gstreamer-1.0 libdrm gbm egl glesv2 freetype2 zlib
+)"
 printf '%s\n' \
   '#include <Poco/Net/IPAddress.h>' \
   '#include <gst/gst.h>' \
-  'int main() { Poco::Net::IPAddress address; gst_init(nullptr, nullptr); return address.isWildcard(); }' \
+  '#include <xf86drm.h>' \
+  '#include <gbm.h>' \
+  '#include <EGL/egl.h>' \
+  '#include <GLES2/gl2.h>' \
+  '#include <ft2build.h>' \
+  '#include FT_FREETYPE_H' \
+  '#include <zlib.h>' \
+  'int main() {' \
+  '  Poco::Net::IPAddress address;' \
+  '  gst_init(nullptr, nullptr);' \
+  '  drmVersionPtr drm_version = drmGetVersion(-1);' \
+  '  gbm_device* gbm = gbm_create_device(-1);' \
+  '  EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY);' \
+  '  const GLubyte* gl_version = glGetString(GL_VERSION);' \
+  '  FT_Library freetype = nullptr;' \
+  '  int ft_status = FT_Init_FreeType(&freetype);' \
+  '  const char* zlib_version = zlibVersion();' \
+  '  return address.isWildcard() + (drm_version != nullptr) + (gbm != nullptr)' \
+  '      + (display != EGL_NO_DISPLAY) + (gl_version != nullptr) + ft_status' \
+  '      + (zlib_version == nullptr);' \
+  '}' \
   | "${compiler}" --sysroot="${sysroot}" -x c++ - \
-      $(pkg-config --cflags --libs gstreamer-1.0) \
+      "${pkg_config_flags[@]}" \
       -L"${gcc_runtime_dir}" \
       -L"${sysroot}/usr/lib/${triplet}" \
       -L"${sysroot}/lib/${triplet}" \

--- a/scripts/validate_cross_sysroot.sh
+++ b/scripts/validate_cross_sysroot.sh
@@ -50,10 +50,10 @@ printf '%s\n' \
   '  const GLubyte* gl_version = glGetString(GL_VERSION);' \
   '  FT_Library freetype = nullptr;' \
   '  int ft_status = FT_Init_FreeType(&freetype);' \
-  '  const char* zlib_version = zlibVersion();' \
+  '  const char* linked_zlib_version = zlibVersion();' \
   '  return address.isWildcard() + (drm_version != nullptr) + (gbm != nullptr)' \
   '      + (display != EGL_NO_DISPLAY) + (gl_version != nullptr) + ft_status' \
-  '      + (zlib_version == nullptr);' \
+  '      + (linked_zlib_version == nullptr);' \
   '}' \
   | "${compiler}" --sysroot="${sysroot}" -x c++ - \
       "${pkg_config_flags[@]}" \


### PR DESCRIPTION
## What changed
- extend the Bullseye ARM64 and ARMHF sysroots with DRM, GBM, EGL, GLES, FreeType, and zlib development files
- validate the combined OpenHD and Glide dependency/linking surface
- install GPG explicitly for Debian archive verification

## Why
OpenHD and OpenHD-Glide can now consume the same verified cross sysroots instead of maintaining separate dependency roots.

## Checks
- Bash syntax validation
- workflow YAML parsing
- `git diff --check`